### PR TITLE
Update 04_cache.ipynb

### DIFF
--- a/section_2/04_cache.ipynb
+++ b/section_2/04_cache.ipynb
@@ -55,7 +55,7 @@
       "outputs": [],
       "source": [
         "!pip install streamlit==1.20.0 --quiet\n",
-        "!pip install --quiet"
+        "!pip install pyngrok--quiet"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "cell_type": "markdown",
       "source": [
         "## ●キャッシュの利用\n",
-        "キャッシュを利用するためには、`@st.cache`の記述で関数を修飾します。"
+        "キャッシュを利用するためには、`@st.cache_data`の記述で関数を修飾します。"
       ],
       "metadata": {
         "id": "5fOtVgU5duPe"
@@ -101,9 +101,9 @@
         "import time\n",
         "\n",
         "# ---------- キャッシュによる時間短縮 ----------\n",
-        "st.title(\"@st.cache\")\n",
+        "st.title(\"@st.cache_data\")\n",
         "\n",
-        "@st.cache  # ←この表記の下の関数がキャッシュされる\n",
+        "@st.cache_data  # ←この表記の下の関数がキャッシュされる\n",
         "def my_heavy_func(a, b):\n",
         "    c = 0\n",
         "    for i in range(10000000):  # 意味の無い重い処理\n",


### PR DESCRIPTION
演習中に、以下に気がつきましたので修正版をお送りしてみます。

- pip install で pyngrok の指定が抜けていたので追加しました。
- st.cache は deprecate されたというメッセージが実行時に表示されたため、新しい st.cache_data に差し替えています。